### PR TITLE
leverage s3fs sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         python3-pip \
         python3-venv \
         ruby \
+        s3fs \
         software-properties-common \
         sudo \
         tree \

--- a/nps-workspace
+++ b/nps-workspace
@@ -2,9 +2,10 @@
 
 import argparse
 import os
+import pathlib
 import subprocess
 
-valid_commands = ['fetch', 'push']
+valid_commands = ['fetch', 'push', 'sync']
 
 valid_users = [
   'bbingham',
@@ -34,5 +35,8 @@ elif args.command == 'push':
     if not os.path.exists(user_dir):
     	parser.error(f'Directory does not exist {user_dir}')
     cmd = f'aws s3 sync {user_dir} s3://nps-cloudsim/{args.username} {delete_string}'
+elif args.command == 'sync':
+    pathlib.Path(user_dir).mkdir(parents=True, exist_ok=True)
+    cmd = f's3fs nps-cloudsim:/{args.username} {user_dir}'
 print(f'Running: {cmd}')
 subprocess.check_call(cmd.split())


### PR DESCRIPTION
This enables using s3fs

Nate recently added the necessary arguments to the kubernetes but I have not been able to start an instance myself.

To use this new functionality

```
export AWSACCESSKEYID=<KEY_ID>
export AWSSECRETACCESSKEY=<SECRET_KEY>

nps-workspace sync <USERNAME>
```

And then `~/username` should be mounted and sync with S3 on read and write. 

I have tested this locallly. To do so  there's a new rocker argument `--fuse` which is necessary. Make sure novnc-rocker is up to date with https://github.com/tfoote/novnc-rocker/pull/6

